### PR TITLE
Add activity indicators to weighted average in binned table

### DIFF
--- a/lbl/science/general.py
+++ b/lbl/science/general.py
@@ -1510,7 +1510,7 @@ def make_rdb_table2(inst: InstrumentsType, rdb_table: Table) -> Table:
     for colname in rdb_table.colnames:
         rdb_dict2[colname] = []
     # -------------------------------------------------------------------------
-    # Determine columsn that use weighted mean
+    # Determine columns that use weighted mean
     vrad_colnames = [cn for cn in rdb_table.colnames if cn.startswith("vrad")]
     svrad_colnames = [
         cn for cn in rdb_table.colnames if cn.startswith("svrad")
@@ -1535,7 +1535,7 @@ def make_rdb_table2(inst: InstrumentsType, rdb_table: Table) -> Table:
             # -----------------------------------------------------------------
             # if column requires wmean, combine value and error
             if colname in wmean_pairs:
-                # get rv and error rv for this udate
+                # get value and error for this udate
                 vals = itable[colname]
                 errs = itable[wmean_pairs[colname]]
                 # get error^2


### PR DESCRIPTION
Previously, only `vrad*` columns and their errors (`svrad*`) were included in the weighted mean. This adds the activity indicators (`d*v`, `fwhm`) and their errors to the columns that are binned with a weighted mean.

Because for activity indicators the error is not just `"s{colname}"`, I created a dictionary that maps values to errors. Then the dictionary is used to get the error column.

EDIT: I have not tested the changes. Let me know if I should create a unit test for this or if I should run it on test data.