### PR TITLE
HARPSN: accomodate to newer blaze loader

### DIFF
--- a/lbl/instruments/harpsn.py
+++ b/lbl/instruments/harpsn.py
@@ -847,7 +847,6 @@ class HarpsN_ORIG(HarpsN):
         io.check_file_exists(abspath)
         # read blaze file
         blaze = io.load_fits(abspath, kind='blaze fits file')
-
         # normalize by order
         if normalize:
             # normalize blaze per order

--- a/lbl/instruments/harpsn.py
+++ b/lbl/instruments/harpsn.py
@@ -845,15 +845,8 @@ class HarpsN_ORIG(HarpsN):
         abspath = os.path.join(calib_directory, blaze_file)
         # check that this file exists
         io.check_file_exists(abspath)
-        # read blaze file (data and header)
-        try:
-            blaze, _ = io.load_fits(abspath, kind='blaze fits file')
-        except ValueError as e:
-            # get only data if no header
-            if str(e) == "too many values to unpack (expected 2)":
-                blaze = io.load_fits(abspath, kind='blaze fits file')
-            else:
-                raise
+        # read blaze file
+        blaze = io.load_fits(abspath, kind='blaze fits file')
 
         # normalize by order
         if normalize:

--- a/lbl/instruments/harpsn.py
+++ b/lbl/instruments/harpsn.py
@@ -846,7 +846,15 @@ class HarpsN_ORIG(HarpsN):
         # check that this file exists
         io.check_file_exists(abspath)
         # read blaze file (data and header)
-        blaze, _ = io.load_fits(abspath, kind='blaze fits file')
+        try:
+            blaze, _ = io.load_fits(abspath, kind='blaze fits file')
+        except ValueError as e:
+            # get only data if no header
+            if str(e) == "too many values to unpack (expected 2)":
+                blaze = io.load_fits(abspath, kind='blaze fits file')
+            else:
+                raise
+
         # normalize by order
         if normalize:
             # normalize blaze per order


### PR DESCRIPTION
Hello,

I deal with cases where blaze files are not readily available for every observation, and only one common daily blaze file is provided. Some times they don't have headers, which leads to an error of this kind:
```
Traceback (most recent call last):
  File "/lbl/recipes/lbl_template.py", line 79, in main
    namespace = __main__(inst)
  File "/lbl/recipes/lbl_template.py", line 185, in __main__
    bout = inst.load_blaze_from_science(*bargs, normalize=False)
  File "/lbl/instruments/harpsn.py", line 849, in load_blaze_from_science
    blaze, _ = io.load_fits(abspath, kind='blaze fits file')
ValueError: too many values to unpack (expected 2)

```
Because LBL [unpacks the data-header tuple and discards the header anyway](https://github.com/njcuk9999/lbl/blob/f5348d54c07e29e60080b2027093ed9508816c84/lbl/instruments/harpsn.py#L849C2-L849C2), I thought it might be useful to catch this error.