### PR TITLE
fix FITS violations before loading files

### DIFF
--- a/lbl/core/io.py
+++ b/lbl/core/io.py
@@ -573,6 +573,7 @@ def load_hdu(filename: str,
     hdu.verify('silentfix')
     return hdu
 
+
 def load_fits(filename: str,
               kind: Union[str, None] = None,
               extnum: Optional[int] = None,

--- a/lbl/core/io.py
+++ b/lbl/core/io.py
@@ -540,40 +540,6 @@ def clean_directory(path: str, logmsg: bool = True,
 # =============================================================================
 # Define fits functions
 # =============================================================================
-def load_hdu(filename: str,
-              kind: Union[str, None] = None,
-              extnum: Optional[int] = None,
-              extname: Optional[str] = None) -> fits.HDUList:
-    """
-    Standard way to load fits header-data unit
-
-    :param filename: str, the filename
-    :param kind: the kind (for error message)
-    :param extnum: int, the extension number (if not given uses first)
-    :param extname: the extension name (if not given uses extnum)
-
-    :return: FITS header, the header
-    """
-    # deal with no kind
-    if kind is None:
-        kind = 'fits file'
-    # try to load fits file
-    try:
-        if extnum is not None:
-            hdu = fits.open(filename, ext=extnum)
-        elif extname is not None:
-            hdu = fits.open(filename, extname=extname)
-        else:
-            hdu = fits.open(filename, extname=extname)
-    except Exception as e:
-        emsg = 'Cannot load {0}. Filename: {1} \n\t{2}: {3}'
-        eargs = [kind, filename, type(e), str(e)]
-        raise LblException(emsg.format(*eargs))
-    # attempt to verify hdu https://github.com/njcuk9999/lbl/pull/45
-    hdu.verify('silentfix')
-    return hdu
-
-
 def load_fits(filename: str,
               kind: Union[str, None] = None,
               extnum: Optional[int] = None,
@@ -588,8 +554,22 @@ def load_fits(filename: str,
 
     :return: tuple, the data and the header
     """
-    hdu = load_hdu(filename, kind, extnum, extname)
-    return hdu[0].data
+    # deal with no kind
+    if kind is None:
+        kind = 'fits file'
+    # try to load fits file
+    try:
+        if extnum is not None:
+            data = fits.getdata(filename, ext=extnum)
+        elif extname is not None:
+            data = fits.getdata(filename, extname=extname)
+        else:
+            data = fits.getdata(filename)
+    except Exception as e:
+        emsg = 'Cannot load {0}. Filename: {1} \n\t{2}: {3}'
+        eargs = [kind, filename, type(e), str(e)]
+        raise LblException(emsg.format(*eargs))
+    return np.array(data)
 
 
 def load_header(filename: str,
@@ -606,8 +586,22 @@ def load_header(filename: str,
 
     :return: FITS header, the header
     """
-    hdu = load_hdu(filename, kind, extnum, extname)
-    return hdu[0].header
+    # deal with no kind
+    if kind is None:
+        kind = 'fits file'
+    # try to load fits file
+    try:
+        if extnum is not None:
+            header = fits.getheader(filename, ext=extnum)
+        elif extname is not None:
+            header = fits.getheader(filename, extname=extname)
+        else:
+            header = fits.getheader(filename)
+    except Exception as e:
+        emsg = 'Cannot load {0}. Filename: {1} \n\t{2}: {3}'
+        eargs = [kind, filename, type(e), str(e)]
+        raise LblException(emsg.format(*eargs))
+    return header.copy()
 
 
 def copy_header(header1: fits.Header, header2: fits.Header) -> fits.Header:

--- a/lbl/core/io.py
+++ b/lbl/core/io.py
@@ -540,6 +540,38 @@ def clean_directory(path: str, logmsg: bool = True,
 # =============================================================================
 # Define fits functions
 # =============================================================================
+def load_hdu(filename: str,
+                kind: Union[str, None] = None,
+                extnum: Optional[int] = None,
+                extname: Optional[str] = None) -> fits.HDUList:
+    """
+    Standard way to load fits header-data unit
+
+    :param filename: str, the filename
+    :param kind: the kind (for error message)
+    :param extnum: int, the extension number (if not given uses first)
+    :param extname: the extension name (if not given uses extnum)
+
+    :return: FITS header, the header
+    """
+    # deal with no kind
+    if kind is None:
+        kind = 'fits file'
+    # try to load fits file
+    try:
+        if extnum is not None:
+            hdu = fits.open(filename, ext=extnum)
+        elif extname is not None:
+            hdu = fits.open(filename, extname=extname)
+        else:
+            hdu = fits.open(filename, extname=extname)
+    except Exception as e:
+        emsg = 'Cannot load {0}. Filename: {1} \n\t{2}: {3}'
+        eargs = [kind, filename, type(e), str(e)]
+        raise LblException(emsg.format(*eargs))
+    hdu.verify('silentfix')
+    return hdu
+
 def load_fits(filename: str,
               kind: Union[str, None] = None,
               extnum: Optional[int] = None,

--- a/lbl/core/io.py
+++ b/lbl/core/io.py
@@ -569,7 +569,7 @@ def load_hdu(filename: str,
         emsg = 'Cannot load {0}. Filename: {1} \n\t{2}: {3}'
         eargs = [kind, filename, type(e), str(e)]
         raise LblException(emsg.format(*eargs))
-    # attempt to verify hdu https://github.com/njcuk9999/lbl/pull/44
+    # attempt to verify hdu https://github.com/njcuk9999/lbl/pull/45
     hdu.verify('silentfix')
     return hdu
 

--- a/lbl/core/io.py
+++ b/lbl/core/io.py
@@ -541,9 +541,9 @@ def clean_directory(path: str, logmsg: bool = True,
 # Define fits functions
 # =============================================================================
 def load_hdu(filename: str,
-                kind: Union[str, None] = None,
-                extnum: Optional[int] = None,
-                extname: Optional[str] = None) -> fits.HDUList:
+              kind: Union[str, None] = None,
+              extnum: Optional[int] = None,
+              extname: Optional[str] = None) -> fits.HDUList:
     """
     Standard way to load fits header-data unit
 

--- a/lbl/core/io.py
+++ b/lbl/core/io.py
@@ -591,12 +591,17 @@ def load_header(filename: str,
         kind = 'fits file'
     # try to load fits file
     try:
-        if extnum is not None:
-            header = fits.getheader(filename, ext=extnum)
-        elif extname is not None:
-            header = fits.getheader(filename, extname=extname)
-        else:
-            header = fits.getheader(filename)
+        with fits.open(filename) as hdu:
+            hdu.verify('silentfix')
+            if extnum is not None:
+                raw_hdr = hdu[extnum].header
+                header = raw_hdr.copy()
+            elif extname is not None:
+                raw_hdr = hdu[extname].header
+                header = raw_hdr.copy()
+            else:
+                raw_hdr = hdu[0].header
+                header = raw_hdr.copy()
     except Exception as e:
         emsg = 'Cannot load {0}. Filename: {1} \n\t{2}: {3}'
         eargs = [kind, filename, type(e), str(e)]

--- a/lbl/core/io.py
+++ b/lbl/core/io.py
@@ -554,22 +554,8 @@ def load_fits(filename: str,
 
     :return: tuple, the data and the header
     """
-    # deal with no kind
-    if kind is None:
-        kind = 'fits file'
-    # try to load fits file
-    try:
-        if extnum is not None:
-            data = fits.getdata(filename, ext=extnum)
-        elif extname is not None:
-            data = fits.getdata(filename, extname=extname)
-        else:
-            data = fits.getdata(filename)
-    except Exception as e:
-        emsg = 'Cannot load {0}. Filename: {1} \n\t{2}: {3}'
-        eargs = [kind, filename, type(e), str(e)]
-        raise LblException(emsg.format(*eargs))
-    return np.array(data)
+    hdu = load_hdu(filename, kind, extnum, extname)
+    return hdu[0].data
 
 
 def load_header(filename: str,
@@ -586,22 +572,8 @@ def load_header(filename: str,
 
     :return: FITS header, the header
     """
-    # deal with no kind
-    if kind is None:
-        kind = 'fits file'
-    # try to load fits file
-    try:
-        if extnum is not None:
-            header = fits.getheader(filename, ext=extnum)
-        elif extname is not None:
-            header = fits.getheader(filename, extname=extname)
-        else:
-            header = fits.getheader(filename)
-    except Exception as e:
-        emsg = 'Cannot load {0}. Filename: {1} \n\t{2}: {3}'
-        eargs = [kind, filename, type(e), str(e)]
-        raise LblException(emsg.format(*eargs))
-    return header.copy()
+    hdu = load_hdu(filename, kind, extnum, extname)
+    return hdu[0].header
 
 
 def copy_header(header1: fits.Header, header2: fits.Header) -> fits.Header:

--- a/lbl/core/io.py
+++ b/lbl/core/io.py
@@ -569,6 +569,7 @@ def load_hdu(filename: str,
         emsg = 'Cannot load {0}. Filename: {1} \n\t{2}: {3}'
         eargs = [kind, filename, type(e), str(e)]
         raise LblException(emsg.format(*eargs))
+    # attempt to verify hdu https://github.com/njcuk9999/lbl/pull/44
     hdu.verify('silentfix')
     return hdu
 


### PR DESCRIPTION
If you work with FITS files that do not conform with the standard, astropy throws a similar error during tellucleaning:
```
Traceback (most recent call last):
  File "lbl/recipes/lbl_telluclean.py", line 75, in main
    namespace = __main__(inst)
  File "lbl/recipes/lbl_telluclean.py", line 169, in __main__
    sci_image, sci_hdr = inst.load_science_file(filename)
  File "lbl/instruments/default.py", line 750, in load_science_file
    sci_hdr = self.load_header(science_file, kind='science fits file')
  File "lbl/instruments/harpsn.py", line 303, in load_header
    return io.LBLHeader.from_fits(hdr, filename)
  File "lbl/core/io.py", line 180, in from_fits
    new[key] = copy.deepcopy(header[key])
  File "/astropy/io/fits/header.py", line 177, in __getitem__
    value = card.value
  File "/astropy/io/fits/card.py", line 293, in value
    value = self._value = self._parse_value()
  File "/astropy/io/fits/card.py", line 764, in _parse_value
    raise VerifyError(
astropy.io.fits.verify.VerifyError: Unparsable card (TNG EXP_METER_B EXP CENTROID), fix it first with .verify('fix').
```
In this case some of my spectra have an unparsable card (`TNG EXP_METER_B EXP CENTROID`), which causes the fatal error. However, [Astropy has some verification procedures that can "fix" the FITS]((https://docs.astropy.org/en/stable/io/fits/usage/verification.html)), so that LBL accepts it. This PR aims to implement this.

From what I understand, the main IO functions in the project are `load_fits` and `load_header` in lbl/core/io.py. They rely on astropy's `fits.getdata` and `fits.getheader` respectively; but [astropy's verification works only for high-level class objects](https://docs.astropy.org/en/stable/io/fits/usage/verification.html#verifications-at-different-data-object-levels).

The only solution I found so far is to define a common function that loads the HDU first, corrects it and gets wrapped by `load_header` and `load_data`:
```py
def load_hdu(filename: str,
              kind: Union[str, None] = None,
              extnum: Optional[int] = None,
              extname: Optional[str] = None) -> fits.HDUList:
    # deal with no kind
    if kind is None:
        kind = 'fits file'
    # try to load fits file
    try:
        if extnum is not None:
            hdu = fits.open(filename, ext=extnum)
        elif extname is not None:
            hdu = fits.open(filename, extname=extname)
        else:
            hdu = fits.open(filename, extname=extname)
    except Exception as e:
        emsg = 'Cannot load {0}. Filename: {1} \n\t{2}: {3}'
        eargs = [kind, filename, type(e), str(e)]
        raise LblException(emsg.format(*eargs))
    # attempt to verify hdu https://github.com/njcuk9999/lbl/pull/44
    hdu.verify('silentfix')
    return hdu

def load_fits(filename: str,
              kind: Union[str, None] = None,
              extnum: Optional[int] = None,
              extname: Optional[str] = None) -> np.ndarray:
    hdu = load_hdu(filename, kind, extnum, extname)
    return hdu[0].data


def load_header(filename: str,
                kind: Union[str, None] = None,
                extnum: Optional[int] = None,
                extname: Optional[str] = None) -> fits.Header:
    hdu = load_hdu(filename, kind, extnum, extname)
    return hdu[0].header
```
It looks a bit ugly. Additionally, I am not sure if `kind`, `extnum`, `extname` will be carried over correctly to fits.open -- I dug in astropy's source code but could not figure it out. My tellucleaning works without error, and I am rather inclined to think that the astropy verification this won't affect the science (unless LBL looks for very specific keywords).

The global diff is quite convoluted; I suggest to look at the commit diffs one at a time, if you are interested.