### PR TITLE
dTemp model normalization issue

### DIFF
--- a/lbl/science/general.py
+++ b/lbl/science/general.py
@@ -1391,7 +1391,7 @@ def compute_rv(inst: InstrumentsType, sci_iteration: int,
                     # loop around residual project tables
                     for key in inst.params['RESPROJ_TABLES']:
                         # calculate spline
-                        rp_spline = splines[key](wave_ord) * b_ratio
+                        rp_spline = splines[key](wave_ord)# * b_ratio
                         # The models are always expressed in terms of the
                         # original spectrum
                         # rblaze = np.nanmedian(sci_data0[order_num] / blaze_ord)


### PR DESCRIPTION
The projection models do not need to be re-blazed or adjusted with a scaling factor. The gradient files are in flux per Kelvin. This operation (*b_ratio) messes with the gradient file and will affect the amplitude of the dTemp, specially when there is continuum variations (e.g., more or less blue extinction in the optical) from spectrum to spectrum.